### PR TITLE
[Front - BugFix] - Filas aparecendo indevidamente para usuários não autorizados

### DIFF
--- a/frontend/src/components/NotificationsPopOver/index.js
+++ b/frontend/src/components/NotificationsPopOver/index.js
@@ -108,10 +108,13 @@ const NotificationsPopOver = () => {
 		});
 
 		socket.on("appMessage", data => {
+			const queueUserIds = user.queues.map(({id}) => id);
+
 			if (
 				data.action === "create" &&
 				!data.message.read &&
-				(data.ticket.userId === user?.id || !data.ticket.userId)
+				(data.ticket.userId === user?.id || !data.ticket.userId) &&
+				queueUserIds.includes(data.ticket.queueId)
 			) {
 				setNotifications(prevState => {
 					const ticketIndex = prevState.findIndex(t => t.id === data.ticket.id);


### PR DESCRIPTION
# Objetivo
Cada usuário pertence tem acesso a filas específicas. Podendo ser mais de uma. Contudo, está ocorrendo de aparecer filas para usuários que não em a autorização de visualiza-las. Isto está gerando uma inconsistência de segurança.

É preciso fazer que cada usuário, veja apenas as suas filas correspondentes e previamente definidas.

Este PR entrega esta solução.

