### PR TITLE
[Fix] - Corrigindo filtro de pesquisa de contatos/mensagens

### DIFF
--- a/frontend/src/components/TicketsList/index.js
+++ b/frontend/src/components/TicketsList/index.js
@@ -190,6 +190,7 @@ const TicketsList = (props) => {
 
   useEffect(() => {
     const socket = openSocket(process.env.REACT_APP_BACKEND_URL);
+    const nullSearchParam = searchParam === undefined || searchParam === null;
 
     const shouldUpdateTicket = (ticket) =>
       (!ticket.userId || ticket.userId === user?.id || showAll) &&
@@ -230,23 +231,25 @@ const TicketsList = (props) => {
       }
     });
 
-    socket.on("appMessage", (data) => {
-      if (data.action === "create" && shouldUpdateTicket(data.ticket)) {
-        dispatch({
-          type: "UPDATE_TICKET_UNREAD_MESSAGES",
-          payload: data.ticket,
-        });
-      }
-    });
+    if (nullSearchParam) {
+      socket.on("appMessage", (data) => {
+        if (data.action === "create" && shouldUpdateTicket(data.ticket)) {
+          dispatch({
+            type: "UPDATE_TICKET_UNREAD_MESSAGES",
+            payload: data.ticket,
+          });
+        }
+      });
 
-    socket.on("contact", (data) => {
-      if (data.action === "update") {
-        dispatch({
-          type: "UPDATE_TICKET_CONTACT",
-          payload: data.contact,
-        });
-      }
-    });
+      socket.on("contact", (data) => {
+        if (data.action === "update") {
+          dispatch({
+            type: "UPDATE_TICKET_CONTACT",
+            payload: data.contact,
+          });
+        }
+      });
+    }
 
     return () => {
       socket.disconnect();

--- a/frontend/src/pages/Contacts/index.js
+++ b/frontend/src/pages/Contacts/index.js
@@ -130,6 +130,8 @@ const Contacts = () => {
   }, [searchParam, pageNumber]);
 
   useEffect(() => {
+    if (searchParam) return;
+
     const socket = openSocket(process.env.REACT_APP_BACKEND_URL);
 
     socket.on("contact", (data) => {
@@ -145,7 +147,7 @@ const Contacts = () => {
     return () => {
       socket.disconnect();
     };
-  }, []);
+  }, [searchParam]);
 
   const handleSearch = (event) => {
     setSearchParam(event.target.value.toLowerCase());


### PR DESCRIPTION
Na pesquisa de contatos retorna números diferentes do informado para pesquisa. O problema acontecia quando fazia uma busca no campo de pesquisa e chegava uma nova mensagem. Como o socket estava aberto e a aplicação estava escutando a fila de "contatos" e "appMessage", toda vida que havia uma mudança lá, refletia na lista dos resultados da busca.

Este PR resolve este problema.